### PR TITLE
change python version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.5"
+  - "3.6"
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
biopython requiring python version 3.6 rather than current 3.5. The version is changed in the travis.yml

```diff
python:
-      - "3.5"
+      - "3.6"
```